### PR TITLE
chore: Adds package publishing to artifactory

### DIFF
--- a/package.json
+++ b/package.json
@@ -15,6 +15,7 @@
   },
   "license": "Apache 2.0",
   "devDependencies": {
+    "@okta/ci-append-sha": "1.3.0-gfe2a1fe",
     "babel-eslint": "^10.1.0",
     "eslint": "^7.13.0",
     "eslint-plugin-jest": "^24.1.3",

--- a/scripts/publish.sh
+++ b/scripts/publish.sh
@@ -2,6 +2,70 @@
 
 source ${OKTA_HOME}/${REPO}/scripts/setup.sh
 
-echo "Publish logic TBD."
+if [ -n "${action_branch}" ];
+then
+  echo "Publishing from bacon task using branch ${action_branch}"
+  TARGET_BRANCH=${action_branch}
+else
+  echo "Publishing from bacon testSuite using branch ${BRANCH}"
+  TARGET_BRANCH=${BRANCH}
+fi
+
+function publish_changes() {
+  # Find base git reference to build changes since
+  if echo "${BRANCH}" | grep -Eq "(^master$)"; then
+    CURRENT_BRANCH=`git log HEAD~1 --pretty=format:"%H" -n 50`
+    BACON_SHAS=`get_bacon_shas_for_artifact $REPO master`
+    BASE_REF=`grep -x -f <(echo "$CURRENT_BRANCH") <(echo "$BACON_SHAS") | head -1`
+  else
+    CURRENT_BRANCH=`git log --pretty=format:"%H" -n 50`
+    MAIN_BRANCH=`git log origin/master --pretty=format:"%H" -n 50`
+    BASE_REF=`grep -x -f <(echo "$CURRENT_BRANCH") <(echo "$MAIN_BRANCH") | head -1`
+  fi
+
+  # Set Lerna options to perform selective pubish
+  if [[ -z $BASE_REF ]]; then
+    LERNA_OPTIONS=""
+  else
+    echo "Publishing changes between $BRANCH...$BASE_REF"
+    LERNA_OPTIONS="--since $BASE_REF --include-dependents"
+  fi
+
+  # Override default registry
+  REGISTRY="${ARTIFACTORY_URL}/api/npm/npm-topic"
+  npm config set @okta:registry ${REGISTRY}
+
+  # Build and publish artifacts
+  echo "Running publish with lerna ${LERNA_OPTIONS}"
+  yarn lerna exec 'ci-append-sha --include-count' ${LERNA_OPTIONS}
+  yarn lerna run build ${LERNA_OPTIONS}
+  yarn lerna exec 'npm publish --verbose' ${LERNA_OPTIONS} --no-private
+  FINAL_PUBLISHED_VERSIONS=$(yarn lerna ls --ndjson ${LERNA_OPTIONS} | grep "^{" | jq -j '.name, "@", .version, "\n"')
+
+  # Upload publish receipt
+  if [[ ! -z $FINAL_PUBLISHED_VERSIONS ]]; then
+    if upload_job_data global publish_receipt "${FINAL_PUBLISHED_VERSIONS}"; then
+      echo "Uploaded publish_receipt to s3!"
+    else
+      echo "Fail to upload publish_receipt to s3!" >&2
+      exit ${BUILD_FAILURE}
+    fi
+
+     # Trigger downstream promotion
+    if [[ "${TARGET_BRANCH}" == "master" ]]; then
+      if ! trigger_and_wait_release_promotion_task 60; then
+        echo "Automatic promotion failed..."
+        exit ${BUILD_FAILURE}
+      fi
+    fi
+  fi
+}
+
+if ! publish_changes; then
+  exit ${BUILD_FAILURE}
+fi
+
+export TEST_SUITE_TYPE="build"
+log_custom_message "Published Versions" "${FINAL_PUBLISHED_VERSIONS}"
 
 exit ${SUCCESS}

--- a/yarn.lock
+++ b/yarn.lock
@@ -1384,6 +1384,17 @@
   dependencies:
     "@types/node" ">= 8"
 
+"@okta/ci-append-sha@1.3.0-gfe2a1fe":
+  version "1.3.0-gfe2a1fe"
+  resolved "https://artifacts.aue1d.saasure.com:443/artifactory/api/npm/npm-okta-all/@okta/ci-append-sha/-/@okta/ci-append-sha-1.3.0-gfe2a1fe.tgz#a70629ac46869485f913143d43739d6e9737b0df"
+  integrity sha1-pwYprEaGlIX5ExQ9Q3Odbpc3sN8=
+  dependencies:
+    commander "2.9.0"
+    git-rev-sync "1.5.0"
+    jsonfile "2.2.3"
+    semver "5.1.0"
+    winston "2.2.0"
+
 "@sinonjs/commons@^1.7.0":
   version "1.8.1"
   resolved "https://artifacts.aue1d.saasure.com:443/artifactory/api/npm/npm-okta-master/@sinonjs/commons/-/commons-1.8.1.tgz#e7df00f98a203324f6dc7cc606cad9d4a8ab2217"
@@ -1820,6 +1831,11 @@ astral-regex@^1.0.0:
   version "1.0.0"
   resolved "https://artifacts.aue1d.saasure.com:443/artifactory/api/npm/npm-okta-master/astral-regex/-/astral-regex-1.0.0.tgz#6c8c3fb827dd43ee3918f27b82782ab7658a6fd9"
   integrity sha1-bIw/uCfdQ+45GPJ7gngqt2WKb9k=
+
+async@~1.0.0:
+  version "1.0.0"
+  resolved "https://artifacts.aue1d.saasure.com:443/artifactory/api/npm/npm-okta-master/async/-/async-1.0.0.tgz#f8fc04ca3a13784ade9e1641af98578cfbd647a9"
+  integrity sha1-+PwEyjoTeErenhZBr5hXjPvWR6k=
 
 asynckit@^0.4.0:
   version "0.4.0"
@@ -2301,6 +2317,11 @@ color-name@~1.1.4:
   resolved "https://artifacts.aue1d.saasure.com:443/artifactory/api/npm/npm-okta-master/color-name/-/color-name-1.1.4.tgz#c2a09a87acbde69543de6f63fa3995c826c536a2"
   integrity sha1-wqCah6y95pVD3m9j+jmVyCbFNqI=
 
+colors@1.0.x:
+  version "1.0.3"
+  resolved "https://artifacts.aue1d.saasure.com:443/artifactory/api/npm/npm-okta-master/colors/-/colors-1.0.3.tgz#0433f44d809680fdeb60ed260f1b0c262e82a40b"
+  integrity sha1-BDP0TYCWgP3rYO0mDxsMJi6CpAs=
+
 columnify@^1.5.4:
   version "1.5.4"
   resolved "https://artifacts.aue1d.saasure.com:443/artifactory/api/npm/npm-okta-master/columnify/-/columnify-1.5.4.tgz#4737ddf1c7b69a8a7c340570782e947eec8e78bb"
@@ -2315,6 +2336,13 @@ combined-stream@^1.0.6, combined-stream@~1.0.6:
   integrity sha1-w9RaizT9cwYxoRCoolIGgrMdWn8=
   dependencies:
     delayed-stream "~1.0.0"
+
+commander@2.9.0:
+  version "2.9.0"
+  resolved "https://artifacts.aue1d.saasure.com:443/artifactory/api/npm/npm-okta-master/commander/-/commander-2.9.0.tgz#9c99094176e12240cb22d6c5146098400fe0f7d4"
+  integrity sha1-nJkJQXbhIkDLItbFFGCYQA/g99Q=
+  dependencies:
+    graceful-readlink ">= 1.0.0"
 
 compare-func@^2.0.0:
   version "2.0.0"
@@ -2532,6 +2560,11 @@ currently-unhandled@^0.4.1:
   integrity sha1-mI3zP+qxke95mmE2nddsF635V+o=
   dependencies:
     array-find-index "^1.0.1"
+
+cycle@1.0.x:
+  version "1.0.3"
+  resolved "https://artifacts.aue1d.saasure.com:443/artifactory/api/npm/npm-okta-master/cycle/-/cycle-1.0.3.tgz#21e80b2be8580f98b468f379430662b046c34ad2"
+  integrity sha1-IegLK+hYD5i0aPN5QwZisEbDStI=
 
 cyclist@^1.0.1:
   version "1.0.1"
@@ -3151,6 +3184,11 @@ extsprintf@^1.2.0:
   resolved "https://artifacts.aue1d.saasure.com:443/artifactory/api/npm/npm-okta-master/extsprintf/-/extsprintf-1.4.0.tgz#e2689f8f356fad62cca65a3a91c5df5f9551692f"
   integrity sha1-4mifjzVvrWLMplo6kcXfX5VRaS8=
 
+eyes@0.1.x:
+  version "0.1.8"
+  resolved "https://artifacts.aue1d.saasure.com:443/artifactory/api/npm/npm-okta-master/eyes/-/eyes-0.1.8.tgz#62cf120234c683785d902348a800ef3e0cc20bc0"
+  integrity sha1-Ys8SAjTGg3hdkCNIqADvPgzCC8A=
+
 fast-deep-equal@^3.1.1:
   version "3.1.3"
   resolved "https://artifacts.aue1d.saasure.com:443/artifactory/api/npm/npm-okta-master/fast-deep-equal/-/fast-deep-equal-3.1.3.tgz#3a7d56b559d6cbc3eb512325244e619a65c6c525"
@@ -3491,6 +3529,14 @@ git-remote-origin-url@^2.0.0:
     gitconfiglocal "^1.0.0"
     pify "^2.3.0"
 
+git-rev-sync@1.5.0:
+  version "1.5.0"
+  resolved "https://artifacts.aue1d.saasure.com:443/artifactory/api/npm/npm-okta-master/git-rev-sync/-/git-rev-sync-1.5.0.tgz#6dc2ad455f76d690ed2bbb5209380f367355edeb"
+  integrity sha1-bcKtRV921pDtK7tSCTgPNnNV7es=
+  dependencies:
+    graceful-fs "4.1.3"
+    shelljs "0.6.0"
+
 git-semver-tags@^2.0.3:
   version "2.0.3"
   resolved "https://artifacts.aue1d.saasure.com:443/artifactory/api/npm/npm-okta-master/git-semver-tags/-/git-semver-tags-2.0.3.tgz#48988a718acf593800f99622a952a77c405bfa34"
@@ -3591,10 +3637,20 @@ globby@^9.2.0:
     pify "^4.0.1"
     slash "^2.0.0"
 
+graceful-fs@4.1.3:
+  version "4.1.3"
+  resolved "https://artifacts.aue1d.saasure.com:443/artifactory/api/npm/npm-okta-master/graceful-fs/-/graceful-fs-4.1.3.tgz#92033ce11113c41e2628d61fdfa40bc10dc0155c"
+  integrity sha1-kgM84RETxB4mKNYf36QLwQ3AFVw=
+
 graceful-fs@^4.1.11, graceful-fs@^4.1.15, graceful-fs@^4.1.2, graceful-fs@^4.1.6, graceful-fs@^4.2.0, graceful-fs@^4.2.2, graceful-fs@^4.2.4:
   version "4.2.4"
   resolved "https://artifacts.aue1d.saasure.com:443/artifactory/api/npm/npm-okta-master/graceful-fs/-/graceful-fs-4.2.4.tgz#2256bde14d3632958c465ebc96dc467ca07a29fb"
   integrity sha1-Ila94U02MpWMRl68ltxGfKB6Kfs=
+
+"graceful-readlink@>= 1.0.0":
+  version "1.0.1"
+  resolved "https://artifacts.aue1d.saasure.com:443/artifactory/api/npm/npm-okta-master/graceful-readlink/-/graceful-readlink-1.0.1.tgz#4cafad76bc62f02fa039b2f94e9a3dd3a391a725"
+  integrity sha1-TK+tdrxi8C+gObL5Tpo906ORpyU=
 
 growly@^1.3.0:
   version "1.3.0"
@@ -4190,7 +4246,7 @@ isobject@^3.0.0, isobject@^3.0.1:
   resolved "https://artifacts.aue1d.saasure.com:443/artifactory/api/npm/npm-okta-master/isobject/-/isobject-3.0.1.tgz#4e431e92b11a9731636aa1f9c8d1ccbcfdab78df"
   integrity sha1-TkMekrEalzFjaqH5yNHMvP2reN8=
 
-isstream@~0.1.2:
+isstream@0.1.x, isstream@~0.1.2:
   version "0.1.2"
   resolved "https://artifacts.aue1d.saasure.com:443/artifactory/api/npm/npm-okta-master/isstream/-/isstream-0.1.2.tgz#47e63f7af55afa6f92e1500e690eb8b8529c099a"
   integrity sha1-R+Y/evVa+m+S4VAOaQ64uFKcCZo=
@@ -4710,6 +4766,11 @@ json5@^2.1.2:
   integrity sha1-ybD3+pIzv+WAf+ZvzzpWF+1ZfUM=
   dependencies:
     minimist "^1.2.5"
+
+jsonfile@2.2.3:
+  version "2.2.3"
+  resolved "https://artifacts.aue1d.saasure.com:443/artifactory/api/npm/npm-okta-master/jsonfile/-/jsonfile-2.2.3.tgz#e252b99a6af901d3ec41f332589c90509a7bc605"
+  integrity sha1-4lK5mmr5AdPsQfMyWJyQUJp7xgU=
 
 jsonfile@^4.0.0:
   version "4.0.0"
@@ -5932,6 +5993,11 @@ pkg-dir@^4.2.0:
   dependencies:
     find-up "^4.0.0"
 
+pkginfo@0.3.x:
+  version "0.3.1"
+  resolved "https://artifacts.aue1d.saasure.com:443/artifactory/api/npm/npm-okta-master/pkginfo/-/pkginfo-0.3.1.tgz#5b29f6a81f70717142e09e765bbeab97b4f81e21"
+  integrity sha1-Wyn2qB9wcXFC4J52W76rl7T4HiE=
+
 posix-character-classes@^0.1.0:
   version "0.1.1"
   resolved "https://artifacts.aue1d.saasure.com:443/artifactory/api/npm/npm-okta-master/posix-character-classes/-/posix-character-classes-0.1.1.tgz#01eac0fe3b5af71a2a6c02feabb8c1fef7e00eab"
@@ -6470,6 +6536,11 @@ saxes@^5.0.0:
   resolved "https://artifacts.aue1d.saasure.com:443/artifactory/api/npm/npm-okta-master/semver/-/semver-5.7.1.tgz#a954f931aeba508d307bbf069eff0c01c96116f7"
   integrity sha1-qVT5Ma66UI0we78Gnv8MAclhFvc=
 
+semver@5.1.0:
+  version "5.1.0"
+  resolved "https://artifacts.aue1d.saasure.com:443/artifactory/api/npm/npm-okta-master/semver/-/semver-5.1.0.tgz#85f2cf8550465c4df000cf7d86f6b054106ab9e5"
+  integrity sha1-hfLPhVBGXE3wAM99hvawVBBqueU=
+
 semver@^6.0.0, semver@^6.2.0, semver@^6.3.0:
   version "6.3.0"
   resolved "https://artifacts.aue1d.saasure.com:443/artifactory/api/npm/npm-okta-master/semver/-/semver-6.3.0.tgz#ee0a64c8af5e8ceea67687b133761e1becbd1d3d"
@@ -6525,6 +6596,11 @@ shebang-regex@^3.0.0:
   version "3.0.0"
   resolved "https://artifacts.aue1d.saasure.com:443/artifactory/api/npm/npm-okta-master/shebang-regex/-/shebang-regex-3.0.0.tgz#ae16f1644d873ecad843b0307b143362d4c42172"
   integrity sha1-rhbxZE2HPsrYQ7AwexQzYtTEIXI=
+
+shelljs@0.6.0:
+  version "0.6.0"
+  resolved "https://artifacts.aue1d.saasure.com:443/artifactory/api/npm/npm-okta-master/shelljs/-/shelljs-0.6.0.tgz#ce1ed837b4b0e55b5ec3dab84251ab9dbdc0c7ec"
+  integrity sha1-zh7YN7Sw5Vtew9q4QlGrnb3Ax+w=
 
 shellwords@^0.1.1:
   version "0.1.1"
@@ -6735,6 +6811,11 @@ ssri@^6.0.0, ssri@^6.0.1:
   integrity sha1-KjxBso3UW2K2Nnbst0ABJlrp7dg=
   dependencies:
     figgy-pudding "^3.5.1"
+
+stack-trace@0.0.x:
+  version "0.0.10"
+  resolved "https://artifacts.aue1d.saasure.com:443/artifactory/api/npm/npm-okta-master/stack-trace/-/stack-trace-0.0.10.tgz#547c70b347e8d32b4e108ea1a2a159e5fdde19c0"
+  integrity sha1-VHxws0fo0ytOEI6hoqFZ5f3eGcA=
 
 stack-utils@^2.0.2:
   version "2.0.3"
@@ -7512,6 +7593,19 @@ windows-release@^3.1.0:
   integrity sha1-HBACfHIldD7sa4nfFg1kwuApOZk=
   dependencies:
     execa "^1.0.0"
+
+winston@2.2.0:
+  version "2.2.0"
+  resolved "https://artifacts.aue1d.saasure.com:443/artifactory/api/npm/npm-okta-master/winston/-/winston-2.2.0.tgz#2c853dd87ab552a8e8485d72cbbf9a2286f029b7"
+  integrity sha1-LIU92Hq1UqjoSF1yy7+aIobwKbc=
+  dependencies:
+    async "~1.0.0"
+    colors "1.0.x"
+    cycle "1.0.x"
+    eyes "0.1.x"
+    isstream "0.1.x"
+    pkginfo "0.3.x"
+    stack-trace "0.0.x"
 
 word-wrap@^1.2.3, word-wrap@~1.2.3:
   version "1.2.3"


### PR DESCRIPTION
### Description

- Publishes monorepo packages to our internal artifactory. For packages that have been published on `master` merges, they will be released to public NPM using the `RELEASE_NPM_PUBLISH_PUBLIC_REGISTRY` task.

**Note:** The script is extremely similar to `okta-ui`'s publish script, which excludes uploading documentation sites to S3.

[Passing Bacon](https://bacon-go.aue1e.saasure.net/commits?artifact=okta-ui-configs&sha=2137e74d3d23360f8af16e385035152f28127416&page=1&pageSize=6)