### PR TITLE
Migrate English string detection rules from okta-ui

### DIFF
--- a/packages/eslint-plugin-okta/README.md
+++ b/packages/eslint-plugin-okta/README.md
@@ -23,6 +23,7 @@ To use this preset, add the following to your configuration file:
 module.exports = {
   extends: [
     'plugin:@okta/okta/recommended',
+    'plugin:@okta/okta/courage-app', // Intended for Courage-based web applications
   ],
 }
 ```
@@ -51,6 +52,8 @@ module.exports = {
 | Rule | Description |
 | -- | -- |
 | [no-exclusive-language](docs/rules/no-exclusive-language.md) | Disallow exclusionary words |
+| [no-unlocalized-text](docs/rules/no-unlocalized-text.md) | disallow hardcoded English text in Courage components |
+| [no-unlocalized-text-in-templates](docs/rules/no-unlocalized-text-in-templates.md) | disallow hardcoded English text in templates
 
 ## Processors
 

--- a/packages/eslint-plugin-okta/docs/rules/no-unlocalized-text-in-templates.md
+++ b/packages/eslint-plugin-okta/docs/rules/no-unlocalized-text-in-templates.md
@@ -1,0 +1,120 @@
+# Disallow using unlocalized text in templates
+
+For packages that utilize the user's locale, no unlocalized text is allowed to be hardcoded into the view template. Developers are required to utilize the `i18n` tag or `loc` utility method to ensure values are localized correctly.
+
+## Rule Details
+
+`'@okta/okta/no-unlocalized-text-in-templates': 2`
+
+## Examples
+
+Examples of **incorrect** code for this rule:
+
+```js
+Okta.View.extend({
+  template: '<div>Hello, world!</div>'
+});
+
+Okta.View.extend({
+    template: '<img src="/img/ui/button/file-browse-01.png" alt="Click me!" class="browse"/>'
+})
+```
+
+```js
+import { tpl } from '@okta/core.common';
+
+const template = tpl(`<p id="myElement" class="greeter">Hello, world!</p>`);
+
+Okta.View.extend({
+  ...
+  this.add(template);
+});
+```
+
+Examples of **correct** code for this rule:
+
+```js
+Okta.View.extend({
+  template: '<div>{{i18n code="mymodule.greeting" bundle="my-module-bundle"}}</div>'
+});
+
+Okta.View.extend({
+    template: '<img src="/img/ui/button/file-browse-01.png" alt={{i18n code="mymodule.browse.alt" bundle="my-module"}} class="browse"/>'
+})
+```
+
+```js
+import { loc, tpl } from '@okta/core.common';
+
+const template = tpl(`<p id="myElement" class="greeter">
+  {{i18n code="mymodule.greeting" bundle="my-module"}}
+</p>`);
+
+// Alternatively
+const template = tpl(
+  '<p id="myElement" class="greeter">{{greeting}}</p>',
+  { greeting: loc('mymodule.greeting', 'my-module') }
+);
+
+// Pass a name through the localization utility
+const template = tpl(
+  '<p id="myElement" class="greeter">{{greeting}}</p>',
+  { greeting: loc('mymodule.greeting.name', 'my-module', [user.firstName]) }
+);
+
+export default View.extend({
+  ...
+  this.add(template);
+});
+```
+
+## Fixing
+
+Support for localization (l10n) is as [easy as 123](https://www.youtube.com/watch?v=diu8i5UKTHc).
+
+1. Verify a `properties` directory and `{my-module}.properties` file exists in your package. If one does not exist, create it matching the following schema:
+
+    ```bash
+    okta-ui/
+      packages/
+        admin/
+          {my-module}/
+            properties/
+              {my-module}.properties
+    ```
+
+2. Create a new unique lookup key based on the context of the string that needs to be translated. This key should be assigned the English String value.
+
+    ```bash
+    # my-module.properties
+
+    # This is the properties bundle for this package. When you need to add a
+    # string to this package, add it to this bundle.
+    mymodule.greeting = Hello, world!
+    mymodule.greeting.name = Hello, {0}!
+    ```
+
+    If the value already exists in the properties file **and** is mapped to a key describing the use case, please reuse the existing key.
+
+    For more information on adding, editing, or deleting keys - adhere to the instructions in the [i18n Dev Process](https://oktawiki.atlassian.net/wiki/spaces/eng/pages/741293778/i18n+dev+process+From+Oct+2019+onwards#I-need-to-add%2Fedit%2Fdelete-strings).
+
+3. Replace the existing unlocalized string with the new property key. You can leverage the `{{i18n}}` tag or `loc` utility function for this:
+
+    ```diff
+    const template = tpl(`
+      <p id="myElement" class="greeter">
+    -   Hello, world!
+    +   {{i18n code="mymodule.greeting" bundle="my-module"}}
+      </p>
+    `);
+    ```
+
+    ```diff
+    const template = tpl(`
+      <p id="myElement" class="greeter">
+    -   Hello, world!
+    +   {{greeting}}
+      </p>
+    -`);
+    + `, { greeting: loc('mymodule.greeting', 'my-module') }
+    ```

--- a/packages/eslint-plugin-okta/docs/rules/no-unlocalized-text.md
+++ b/packages/eslint-plugin-okta/docs/rules/no-unlocalized-text.md
@@ -1,0 +1,94 @@
+# Disallow using unlocalized text in components
+
+For packages that utilize the user's locale, no unlocalized text is allowed to be hardcoded into component attributes. Developers are required to utilize the `loc` utility method to ensure values are localized correctly.
+
+## Rule Details
+
+`'@okta/okta/no-unlocalized-text': 2`
+
+## Examples
+
+Examples of **incorrect** code for this rule:
+
+```js
+Okta.createButton({
+  title: 'Primary Button',
+  className: 'button-primary',
+  click: notify('success', 'Primary button clicked'),
+  visible: true,
+});
+
+Okta.createCallout({
+  size: 'compact',
+  type: 'info',
+  title: 'A compact/info callout with a title',
+});
+```
+
+```js
+Okta.Form.extend({
+  layout: 'o-form-theme',
+  title: 'A form title',
+
+  inputs: [
+    {
+      name: 'a-name',
+      type: 'text',
+      label: 'Using raw explain text',
+      explain: 'Raw explain text',
+    },
+});
+```
+
+Examples of **correct** code for this rule:
+
+```js
+import { loc } from '@okta/core.common';
+
+Okta.createButton({
+  title: loc('button.primary', 'myBundle'), // 'Primary Button'
+  className: 'button-primary',
+  click: notify('success', loc('button.primary.click', 'myBundle'), // 'Primary button clicked'
+  visible: true,
+});
+
+Okta.createCallout({
+  size: 'compact',
+  type: 'info',
+  title: loc('callout.title', 'myBundle'), // 'A compact/info callout with a title'
+});
+```
+
+```js
+import { loc } from '@okta/core.common';
+
+Okta.Form.extend({
+  layout: 'o-form-theme',
+  title: loc('form.title', 'myBundle'), // 'A form title'
+
+  inputs: [
+    {
+      name: 'a-name',
+      type: 'text',
+      label: loc('input.a.name.text', 'myBundle'), // 'Using raw explain text'
+      explain: loc('input.a.name.explain', 'myBundle'), // 'Raw explain text'
+    },
+});
+```
+
+## Fixing
+
+Replace the existing unlocalized string with the new property key. You can leverage the `loc` utility function for this:
+
+```diff
++ import { loc } from '@okta/core.common';
+
+Okta.createButton({
+-  title: 'Primary Button',
++  title: loc('button.primary', 'myBundle'), // 'Primary Button'
+  className: 'button-primary',
+-  click: notify('success', 'Primary button clicked'),
++  click: notify('success', loc('button.primary.click', 'myBundle'), // 'Primary button clicked'
+  visible: true,
+});
+```

--- a/packages/eslint-plugin-okta/index.js
+++ b/packages/eslint-plugin-okta/index.js
@@ -13,9 +13,30 @@ module.exports = {
         },
       ],
     },
+    'courage-app': {
+      plugins: ['@okta/okta'],
+      rules: {
+        '@okta/okta/no-exclusive-language': 1,
+      },
+      overrides: [
+        {
+          files: ['*.properties'],
+          processor: '@okta/okta/properties',
+        },
+        {
+          files: ['*.js'],
+          rules: {
+            '@okta/okta/no-unlocalized-text-in-templates': 2,
+            '@okta/okta/no-unlocalized-text': 2,
+          }
+        }
+      ],
+    }
   },
   rules: {
     'no-exclusive-language': require('./lib/rules/no-exclusive-language'),
+    'no-unlocalized-text-in-templates': require('./lib/rules/no-unlocalized-text-in-templates'),
+    'no-unlocalized-text': require('./lib/rules/no-unlocalized-text'),
   },
   processors: {
     properties: require('./lib/processors/properties')

--- a/packages/eslint-plugin-okta/lib/rules/no-unlocalized-text-in-templates.js
+++ b/packages/eslint-plugin-okta/lib/rules/no-unlocalized-text-in-templates.js
@@ -1,0 +1,57 @@
+const { parseEvidence, scan } = require('../util/no-unlocalized-text/i18nLint');
+
+function isHtml(value) {
+  return /<[a-z]+|[a-z]+>/.test(value);
+}
+
+function isTestFile(filename) {
+  return filename.endsWith('_spec.js');
+}
+
+module.exports = {
+  meta: {
+    type: 'problem',
+    docs: {
+      description: 'Disallow unlocalized string literals in templates',
+      category: 'Best Practice',
+      recommended: true
+    },
+    fixable: null,
+    schema: [],
+    messages: {
+      noUnlocalizedTextInTemplates: 'Unexpected string: {{rawString}}'
+    }
+  },
+
+  create(context) {
+    function report(node, value) {
+      context.report({
+        messageId: 'noUnlocalizedTextInTemplates',
+        data: {
+          rawString: value
+        },
+        node
+      });
+    }
+
+    function check(node) {
+      const isTemplateElement = node.type === 'TemplateElement';
+      const value = isTemplateElement ? node.value.raw : node.raw;
+
+      if (!isHtml(value) || isTestFile(context.getFilename())) {
+        return;
+      }
+
+      scan(value)
+        .forEach(err => {
+          const evidenceString = parseEvidence(err.evidence, err.scope);
+          report(node, evidenceString);
+        });
+    }
+
+    return {
+      Literal: check,
+      TemplateElement: check
+    };
+  }
+};

--- a/packages/eslint-plugin-okta/lib/rules/no-unlocalized-text-in-templates.test.js
+++ b/packages/eslint-plugin-okta/lib/rules/no-unlocalized-text-in-templates.test.js
@@ -1,0 +1,202 @@
+const rule = require('./no-unlocalized-text-in-templates');
+const RuleTester = require('eslint').RuleTester;
+
+const ruleTester = new RuleTester({
+  parser: require.resolve('babel-eslint'),
+  parserOptions: {
+    sourceType: 'module',
+  },
+});
+
+ruleTester.run('no-unlocalized-text-in-templates', rule, {
+  valid: [
+    {code: '"<span>{{type}}</span>"'},
+    {code: '"<div>{{type}}</div>"'},
+    {code: '"<p>\t<p>"'},
+    {code: '`<p>${literal}</p>`'},
+    {code: '"<div>{{{raw}}}</div>"'},
+    {code: '"<div class=\'foo\'><p>{{{raw}}}</p></div>"'},
+    {code: '"<div>{{i18n code=\'app.page.title\'}}</div>"'},
+    {code: '"<script>var foo = \'Bar\';</script>"'},
+    {code: '"<div>{{#if something}}</div>"'},
+    {code: '"<p>{{username}}</p>"'},
+    {code: '"<input placeholder=\'{{placeholder}}\'></input>"'},
+    {code: '"<abbr title=\'{{longTitle}}\'>{{title}}</abbr>"'},
+    {code: '"<span>&nbsp;</span>"'},
+    {code: '"<div>{{higher}} &gt; {{lower}}</div>"'},
+    {
+      code: '"<b>Test Code</b>"',
+      filename: 'Class_spec.js',
+    },
+  ],
+
+  invalid: [
+    {
+      code: '"<span>User</span>"',
+      errors: [
+        {
+          messageId: 'noUnlocalizedTextInTemplates',
+          data: {
+            rawString: 'User',
+          },
+        },
+      ]
+    },
+    {
+      code: '"<div><p>User</p></div>"',
+      errors: [
+        {
+          messageId: 'noUnlocalizedTextInTemplates',
+          data: {
+            rawString: 'User',
+          },
+        }
+      ]
+    },
+    {
+      code: '"<div>{{type}} and text</div>"',
+      errors: [
+        {
+          messageId: 'noUnlocalizedTextInTemplates',
+          data: {
+            rawString: 'and text',
+          },
+        }
+      ]
+    },
+    {
+      code: '"<a href=\'{{{url}}}\'>Link text</a>"',
+      errors: [
+        {
+          messageId: 'noUnlocalizedTextInTemplates',
+          data: {
+            rawString: 'Link text',
+          },
+        }
+      ]
+    },
+    {
+      code: '"<div>(required)</div>"',
+      errors: [
+        {
+          messageId: 'noUnlocalizedTextInTemplates',
+          data: {
+            rawString: 'required',
+          },
+        }
+      ]
+    },
+    {
+      code: '"<div>Hello (there) \
+          oh no \
+        </div>"',
+      errors: [
+        {
+          messageId: 'noUnlocalizedTextInTemplates',
+          data: {
+            rawString: 'Hello (there) \
+          oh no',
+          },
+        }
+      ]
+    },
+    {
+      code: '"<div>Test single quotes' +
+      ' here' +
+      '</div>"',
+      errors: [
+        {
+          messageId: 'noUnlocalizedTextInTemplates',
+          data: {
+            rawString: 'Test single quotes here',
+          },
+        }
+      ]
+    },
+    {
+      code: '"<div>Multiple Errors!<p>Try again.</p></div>"',
+      errors: [
+        {
+          messageId: 'noUnlocalizedTextInTemplates',
+          data: {
+            rawString: 'Multiple Errors!',
+          },
+        },
+        {
+          messageId: 'noUnlocalizedTextInTemplates',
+          data: {
+            rawString: 'Try again.',
+          },
+        }
+      ],
+    },
+    {
+      code: '"<b>Test Code</b>"',
+      filename: 'Class_test.js', // Convention is _spec.js
+      errors: [
+        {
+          messageId: 'noUnlocalizedTextInTemplates',
+          data: {
+            rawString: 'Test Code',
+          },
+        },
+      ],
+    },
+    // Accessibility
+    {
+      code: '"<img src=\'file.png\' alt=\'Assistive text\'></img>"',
+      errors: [
+        {
+          messageId: 'noUnlocalizedTextInTemplates',
+          data: {
+            rawString: 'Assistive text',
+          },
+        }
+      ]
+    },
+    {
+      code: '"<button aria-label=\'Exit\'>x</button>"',
+      errors: [
+        {
+          messageId: 'noUnlocalizedTextInTemplates',
+          data: {
+            rawString: 'Exit',
+          },
+        }
+      ]
+    },
+    {
+      code: '"<input placeholder=\'Placeholder\'></input>"',
+      errors: [
+        {
+          messageId: 'noUnlocalizedTextInTemplates',
+          data: {
+            rawString: 'Placeholder',
+          },
+        }
+      ]
+    },
+    {
+      code: '"<abbr title=\'Long title\'>{{title}}</abbr>"',
+      errors: [
+        {
+          messageId: 'noUnlocalizedTextInTemplates',
+          data: {
+            rawString: 'Long title',
+          },
+        }
+      ]
+    },
+    {
+      code: '"<div aria-label=\'Description of the overall image\'><img src=\'img.jpg\' /></div>"',
+      errors: [
+        {
+          messageId: 'noUnlocalizedTextInTemplates',
+          data: {
+            rawString: 'Description of the overall image',
+          },
+        }
+      ]
+    },
+  ],
+});

--- a/packages/eslint-plugin-okta/lib/rules/no-unlocalized-text.js
+++ b/packages/eslint-plugin-okta/lib/rules/no-unlocalized-text.js
@@ -1,0 +1,90 @@
+const { parseEvidence, scan } = require('../util/no-unlocalized-text/i18nLint');
+
+module.exports = {
+  meta: {
+    type: 'problem',
+    docs: {
+      description: 'Disallow unlocalized string literals in specific identifiers',
+      category: 'Best Practice',
+      recommended: true,
+    },
+    fixable: null,
+    schema: [],
+    messages: {
+      noUnlocalizedText: 'Unexpected string: {{rawString}}',
+    }
+  },
+
+  create(context) {
+    function report(node, value) {
+      context.report({
+        messageId: 'noUnlocalizedText',
+        data: {
+          rawString: value,
+        },
+        node,
+      });
+    }
+
+    function isTestFile(filename) {
+      return filename.includes('/test/');
+    }
+
+    function getValueFromTemplate(node) {
+      // Convert templates with vars into a single string
+      // `Hello, ${name}. Welcome to okta-ui.` => 'Hello,. Welcome to okta-ui.'
+      return node
+        .quasis
+        .map(quasi => quasi.value.cooked)
+        .join('');
+    }
+
+    function check(node) {
+      if (isTestFile(context.getFilename())) return;
+
+      const keyIdentifiers = [
+        'content', // This can contain HTML
+        'desc', // autocomplete
+        'hrefName',
+        'label',
+        'placeholder',
+        'save',
+        'subtitle',
+        'text',
+        'title',
+        'tooltip',
+      ];
+
+      const valueIdentifiers = [
+        'Literal',
+        'TemplateLiteral',
+      ];
+
+      const allowedValues = [
+        'string',   // Used for model schemas
+        '',         // Empty strings
+      ];
+  
+      if (keyIdentifiers.includes(node.key.name) && valueIdentifiers.includes(node.value.type)) {
+        const isTemplateElement = node.value.type === 'TemplateLiteral';
+        const value = isTemplateElement ? getValueFromTemplate(node.value) : node.value.value;
+
+        if (typeof value === 'string' && !allowedValues.includes(value.trim())) {
+          if (node.key.name === 'content') {
+            // The `content` key accepts HTML strings, so we parse it here with our I18nLint tool
+            scan(value).forEach(err => {
+              const evidenceString = parseEvidence(err.evidence, err.scope);
+              report(node.value, evidenceString);
+            });
+          } else {
+            report(node.value, value);
+          }
+        }
+      }
+    }
+
+    return {
+      Property: check,
+    };
+  },
+};

--- a/packages/eslint-plugin-okta/lib/rules/no-unlocalized-text.test.js
+++ b/packages/eslint-plugin-okta/lib/rules/no-unlocalized-text.test.js
@@ -1,0 +1,85 @@
+const rule = require('./no-unlocalized-text');
+const RuleTester = require('eslint').RuleTester;
+
+const ruleTester = new RuleTester({
+  parser: require.resolve('babel-eslint'),
+  parserOptions: {
+    sourceType: 'module',
+  },
+});
+
+const buildCode = (key, value) => {
+  return `module.exports = { ${key}: ${value} };`;
+};
+
+ruleTester.run('no-unlocalized-text', rule, {
+  valid: [
+    { code: buildCode('title', 'loc(\'user.name\', \'bundle\')' )},
+    { code: buildCode('label', 'Okta.loc(\'user.name\', \'bundle\')' )},
+
+    // Allowed values
+    { code: buildCode('tooltip', 'null' )},
+    { code: buildCode('tooltip', 'true' )},
+    { code: buildCode('tooltip', 'false' )},
+    { code: buildCode('tooltip', '\'string\'' )},
+    { code: buildCode('tooltip', '\'\'' )},
+    { code: buildCode('tooltip', '\'       \'' )},
+
+    // Special cases with HTML
+    { code: buildCode('content', '\'<p></p>\'') },
+    { code: buildCode('content', '\'<p>{{i18n code="foo" bundle="bar"}}</p>\'') },
+
+    // Test files - omit these as hardcoded values are OK
+    {
+      code: buildCode('title', '\'Foo\''),
+      filename: '/test/Class_spec.js',
+    },
+  ],
+
+  invalid: [
+    {
+      code: buildCode('title', '\'Foo\''),
+      errors: [
+        {
+          messageId: 'noUnlocalizedText',
+          data: {
+            rawString: 'Foo',
+          },
+        },
+      ]
+    },
+    {
+      code: buildCode('label', '\'This is a label.\''),
+      errors: [
+        {
+          messageId: 'noUnlocalizedText',
+          data: {
+            rawString: 'This is a label.',
+          },
+        },
+      ]
+    },
+    {
+      code: buildCode('placeholder', '`Hello, ${world}`'),
+      errors: [
+        {
+          messageId: 'noUnlocalizedText',
+          data: {
+            rawString: 'Hello, ',
+          },
+        },
+      ]
+    },
+    {
+      code: buildCode('content', '`<p>This is a paragraph</p>`'),
+      errors: [
+        {
+          messageId: 'noUnlocalizedText',
+          data: {
+            rawString: 'This is a paragraph',
+          },
+        },
+      ]
+    },
+  ],
+});

--- a/packages/eslint-plugin-okta/lib/util/no-unlocalized-text/i18nLint.js
+++ b/packages/eslint-plugin-okta/lib/util/no-unlocalized-text/i18nLint.js
@@ -1,0 +1,48 @@
+const I18nLint = require('i18n-lint');
+
+const i18nOptions = {
+  attributes: [
+    'alt',
+    'aria-label',
+    'placeholder',
+    'title',
+  ],
+  templateDelimiters: [ '{{', '}}' ], // Handlebars
+};
+
+/**
+ * Returns unlocalized text from the markup.
+ * 
+ * Utilizes the returned evidence RegExp (ex: `"\(Raw String)/"`) to obtain
+ * a string representation of the error.
+ * 
+ * @param {RegExp} evidenceRegExp A regex of the offending text
+ * @param {string} scope Template markup where the error was found
+ * @returns {string} Sanitized unlocalized text value
+ * 
+ */
+function parseEvidence(evidenceRegExp, scope) {
+  const matches = scope.match(evidenceRegExp);
+  let evidenceString = (matches && matches.length) ? matches[0] : evidenceRegExp.toString();
+
+  // The i18n utility sometimes picks up the preceding and trailing single quotes when
+  // templates are passed as multi-line strings. If so, ignore it.
+  if (evidenceString.startsWith('\'')) {
+    evidenceString = evidenceString.substr(1);
+  }
+
+  if (['\'', '\\'].includes(evidenceString[evidenceString.length - 1])) {
+    evidenceString = evidenceString.slice(0, -1);
+  }
+
+  return evidenceString;
+}
+
+function scan(value) {
+  return I18nLint.scan(value, i18nOptions);
+}
+
+module.exports = {
+  parseEvidence,
+  scan,
+};

--- a/packages/eslint-plugin-okta/package.json
+++ b/packages/eslint-plugin-okta/package.json
@@ -12,6 +12,7 @@
   },
   "dependencies": {
     "fs-extra": "^9.0.1",
+    "i18n-lint": "^1.1.0",
     "node-properties-parser": "^0.0.2",
     "properties-to-json": "^0.1.7"
   },

--- a/yarn.lock
+++ b/yarn.lock
@@ -1688,6 +1688,11 @@ ansi-regex@^5.0.0:
   resolved "https://artifacts.aue1d.saasure.com:443/artifactory/api/npm/npm-okta-master/ansi-regex/-/ansi-regex-5.0.0.tgz#388539f55179bf39339c81af30a654d69f87cb75"
   integrity sha1-OIU59VF5vzkznIGvMKZU1p+Hy3U=
 
+ansi-styles@^2.2.1:
+  version "2.2.1"
+  resolved "https://artifacts.aue1d.saasure.com:443/artifactory/api/npm/npm-okta-master/ansi-styles/-/ansi-styles-2.2.1.tgz#b432dd3358b634cf75e1e4664368240533c1ddbe"
+  integrity sha1-tDLdM1i2NM914eRmQ2gkBTPB3b4=
+
 ansi-styles@^3.2.0, ansi-styles@^3.2.1:
   version "3.2.1"
   resolved "https://artifacts.aue1d.saasure.com:443/artifactory/api/npm/npm-okta-master/ansi-styles/-/ansi-styles-3.2.1.tgz#41fbb20243e50b12be0f04b8dedbf07520ce841d"
@@ -2174,6 +2179,17 @@ caseless@~0.12.0:
   resolved "https://artifacts.aue1d.saasure.com:443/artifactory/api/npm/npm-okta-master/caseless/-/caseless-0.12.0.tgz#1b681c21ff84033c826543090689420d187151dc"
   integrity sha1-G2gcIf+EAzyCZUMJBolCDRhxUdw=
 
+chalk@^1.0.0:
+  version "1.1.3"
+  resolved "https://artifacts.aue1d.saasure.com:443/artifactory/api/npm/npm-okta-master/chalk/-/chalk-1.1.3.tgz#a8115c55e4a702fe4d150abd3872822a7e09fc98"
+  integrity sha1-qBFcVeSnAv5NFQq9OHKCKn4J/Jg=
+  dependencies:
+    ansi-styles "^2.2.1"
+    escape-string-regexp "^1.0.2"
+    has-ansi "^2.0.0"
+    strip-ansi "^3.0.0"
+    supports-color "^2.0.0"
+
 chalk@^2.0.0, chalk@^2.3.1, chalk@^2.4.2:
   version "2.4.2"
   resolved "https://artifacts.aue1d.saasure.com:443/artifactory/api/npm/npm-okta-master/chalk/-/chalk-2.4.2.tgz#cd42541677a54333cf541a49108c1432b44c9424"
@@ -2343,6 +2359,11 @@ commander@2.9.0:
   integrity sha1-nJkJQXbhIkDLItbFFGCYQA/g99Q=
   dependencies:
     graceful-readlink ">= 1.0.0"
+
+commander@^2.0.0:
+  version "2.20.3"
+  resolved "https://artifacts.aue1d.saasure.com:443/artifactory/api/npm/npm-okta-master/commander/-/commander-2.20.3.tgz#fd485e84c03eb4881c20722ba48035e8531aeb33"
+  integrity sha1-/UhehMA+tIgcIHIrpIA16FMa6zM=
 
 compare-func@^2.0.0:
   version "2.0.0"
@@ -2765,12 +2786,45 @@ doctrine@^3.0.0:
   dependencies:
     esutils "^2.0.2"
 
+dom-serializer@0:
+  version "0.2.2"
+  resolved "https://artifacts.aue1d.saasure.com:443/artifactory/api/npm/npm-okta-master/dom-serializer/-/dom-serializer-0.2.2.tgz#1afb81f533717175d478655debc5e332d9f9bb51"
+  integrity sha1-GvuB9TNxcXXUeGVd68XjMtn5u1E=
+  dependencies:
+    domelementtype "^2.0.1"
+    entities "^2.0.0"
+
+domelementtype@1, domelementtype@^1.3.1:
+  version "1.3.1"
+  resolved "https://artifacts.aue1d.saasure.com:443/artifactory/api/npm/npm-okta-master/domelementtype/-/domelementtype-1.3.1.tgz#d048c44b37b0d10a7f2a3d5fee3f4333d790481f"
+  integrity sha1-0EjESzew0Qp/Kj1f7j9DM9eQSB8=
+
+domelementtype@^2.0.1:
+  version "2.1.0"
+  resolved "https://artifacts.aue1d.saasure.com:443/artifactory/api/npm/npm-okta-master/domelementtype/-/domelementtype-2.1.0.tgz#a851c080a6d1c3d94344aed151d99f669edf585e"
+  integrity sha1-qFHAgKbRw9lDRK7RUdmfZp7fWF4=
+
 domexception@^2.0.1:
   version "2.0.1"
   resolved "https://artifacts.aue1d.saasure.com:443/artifactory/api/npm/npm-okta-master/domexception/-/domexception-2.0.1.tgz#fb44aefba793e1574b0af6aed2801d057529f304"
   integrity sha1-+0Su+6eT4VdLCvau0oAdBXUp8wQ=
   dependencies:
     webidl-conversions "^5.0.0"
+
+domhandler@^2.3.0:
+  version "2.4.2"
+  resolved "https://artifacts.aue1d.saasure.com:443/artifactory/api/npm/npm-okta-master/domhandler/-/domhandler-2.4.2.tgz#8805097e933d65e85546f726d60f5eb88b44f803"
+  integrity sha1-iAUJfpM9ZehVRvcm1g9euItE+AM=
+  dependencies:
+    domelementtype "1"
+
+domutils@^1.5.1:
+  version "1.7.0"
+  resolved "https://artifacts.aue1d.saasure.com:443/artifactory/api/npm/npm-okta-master/domutils/-/domutils-1.7.0.tgz#56ea341e834e06e6748af7a1cb25da67ea9f8c2a"
+  integrity sha1-Vuo0HoNOBuZ0ivehyyXaZ+qfjCo=
+  dependencies:
+    dom-serializer "0"
+    domelementtype "1"
 
 dot-prop@^4.2.0:
   version "4.2.1"
@@ -2844,6 +2898,16 @@ enquirer@^2.3.5:
   integrity sha1-Kn/l3WNKHkElqXXsmU/1RW3Dc00=
   dependencies:
     ansi-colors "^4.1.1"
+
+entities@^1.1.1:
+  version "1.1.2"
+  resolved "https://artifacts.aue1d.saasure.com:443/artifactory/api/npm/npm-okta-master/entities/-/entities-1.1.2.tgz#bdfa735299664dfafd34529ed4f8522a275fea56"
+  integrity sha1-vfpzUplmTfr9NFKe1PhSKidf6lY=
+
+entities@^2.0.0:
+  version "2.2.0"
+  resolved "https://artifacts.aue1d.saasure.com:443/artifactory/api/npm/npm-okta-master/entities/-/entities-2.2.0.tgz#098dc90ebb83d8dffa089d55256b351d34c4da55"
+  integrity sha1-CY3JDruD2N/6CJ1VJWs1HTTE2lU=
 
 env-paths@^2.2.0:
   version "2.2.0"
@@ -2923,7 +2987,7 @@ es6-promisify@^5.0.0:
   dependencies:
     es6-promise "^4.0.3"
 
-escape-string-regexp@^1.0.5:
+escape-string-regexp@^1.0.2, escape-string-regexp@^1.0.5:
   version "1.0.5"
   resolved "https://artifacts.aue1d.saasure.com:443/artifactory/api/npm/npm-okta-master/escape-string-regexp/-/escape-string-regexp-1.0.5.tgz#1b61c0562190a8dff6ae3bb2cf0200ca130b86d4"
   integrity sha1-G2HAViGQqN/2rjuyzwIAyhMLhtQ=
@@ -3587,6 +3651,17 @@ glob-to-regexp@^0.3.0:
   resolved "https://artifacts.aue1d.saasure.com:443/artifactory/api/npm/npm-okta-master/glob-to-regexp/-/glob-to-regexp-0.3.0.tgz#8c5a1494d2066c570cc3bfe4496175acc4d502ab"
   integrity sha1-jFoUlNIGbFcMw7/kSWF1rMTVAqs=
 
+glob@^5.0.0:
+  version "5.0.15"
+  resolved "https://artifacts.aue1d.saasure.com:443/artifactory/api/npm/npm-okta-master/glob/-/glob-5.0.15.tgz#1bc936b9e02f4a603fcc222ecf7633d30b8b93b1"
+  integrity sha1-G8k2ueAvSmA/zCIuz3Yz0wuLk7E=
+  dependencies:
+    inflight "^1.0.4"
+    inherits "2"
+    minimatch "2 || 3"
+    once "^1.3.0"
+    path-is-absolute "^1.0.0"
+
 glob@^7.1.1, glob@^7.1.2, glob@^7.1.3, glob@^7.1.4:
   version "7.1.6"
   resolved "https://artifacts.aue1d.saasure.com:443/artifactory/api/npm/npm-okta-master/glob/-/glob-7.1.6.tgz#141f33b81a7c2492e125594307480c46679278a6"
@@ -3687,6 +3762,13 @@ hard-rejection@^2.1.0:
   resolved "https://artifacts.aue1d.saasure.com:443/artifactory/api/npm/npm-okta-master/hard-rejection/-/hard-rejection-2.1.0.tgz#1c6eda5c1685c63942766d79bb40ae773cecd883"
   integrity sha1-HG7aXBaFxjlCdm15u0Cudzzs2IM=
 
+has-ansi@^2.0.0:
+  version "2.0.0"
+  resolved "https://artifacts.aue1d.saasure.com:443/artifactory/api/npm/npm-okta-master/has-ansi/-/has-ansi-2.0.0.tgz#34f5049ce1ecdf2b0649af3ef24e45ed35416d91"
+  integrity sha1-NPUEnOHs3ysGSa8+8k5F7TVBbZE=
+  dependencies:
+    ansi-regex "^2.0.0"
+
 has-flag@^3.0.0:
   version "3.0.0"
   resolved "https://artifacts.aue1d.saasure.com:443/artifactory/api/npm/npm-okta-master/has-flag/-/has-flag-3.0.0.tgz#b5d454dc2199ae225699f3467e5a07f3b955bafd"
@@ -3769,6 +3851,18 @@ html-escaper@^2.0.0:
   resolved "https://artifacts.aue1d.saasure.com:443/artifactory/api/npm/npm-okta-master/html-escaper/-/html-escaper-2.0.2.tgz#dfd60027da36a36dfcbe236262c00a5822681453"
   integrity sha1-39YAJ9o2o238viNiYsAKWCJoFFM=
 
+htmlparser2@^3.0.0:
+  version "3.10.1"
+  resolved "https://artifacts.aue1d.saasure.com:443/artifactory/api/npm/npm-okta-master/htmlparser2/-/htmlparser2-3.10.1.tgz#bd679dc3f59897b6a34bb10749c855bb53a9392f"
+  integrity sha1-vWedw/WYl7ajS7EHSchVu1OpOS8=
+  dependencies:
+    domelementtype "^1.3.1"
+    domhandler "^2.3.0"
+    domutils "^1.5.1"
+    entities "^1.1.1"
+    inherits "^2.0.1"
+    readable-stream "^3.1.1"
+
 http-cache-semantics@^3.8.1:
   version "3.8.1"
   resolved "https://artifacts.aue1d.saasure.com:443/artifactory/api/npm/npm-okta-master/http-cache-semantics/-/http-cache-semantics-3.8.1.tgz#39b0e16add9b605bf0a9ef3d9daaf4843b4cacd2"
@@ -3810,6 +3904,17 @@ humanize-ms@^1.2.1:
   integrity sha1-xG4xWaKT9riW2ikxbYtv6Lt5u+0=
   dependencies:
     ms "^2.0.0"
+
+i18n-lint@^1.1.0:
+  version "1.1.0"
+  resolved "https://artifacts.aue1d.saasure.com:443/artifactory/api/npm/npm-okta-master/i18n-lint/-/i18n-lint-1.1.0.tgz#7a468a165be851264843caeb5e455f32c0abba37"
+  integrity sha1-ekaKFlvoUSZIQ8rrXkVfMsCrujc=
+  dependencies:
+    chalk "^1.0.0"
+    commander "^2.0.0"
+    glob "^5.0.0"
+    htmlparser2 "^3.0.0"
+    node.extend "^1.0.0"
 
 iconv-lite@0.4.24, iconv-lite@^0.4.24:
   version "0.4.24"
@@ -4223,6 +4328,11 @@ is-wsl@^2.2.0:
   integrity sha1-dKTHbnfKn9P5MvKQwX6jJs0VcnE=
   dependencies:
     is-docker "^2.0.0"
+
+is@^3.2.1:
+  version "3.3.0"
+  resolved "https://artifacts.aue1d.saasure.com:443/artifactory/api/npm/npm-okta-master/is/-/is-3.3.0.tgz#61cff6dd3c4193db94a3d62582072b44e5645d79"
+  integrity sha1-Yc/23TxBk9uUo9YlggcrROVkXXk=
 
 isarray@1.0.0, isarray@~1.0.0:
   version "1.0.0"
@@ -5204,7 +5314,7 @@ min-indent@^1.0.0:
   resolved "https://artifacts.aue1d.saasure.com:443/artifactory/api/npm/npm-okta-master/min-indent/-/min-indent-1.0.1.tgz#a63f681673b30571fbe8bc25686ae746eefa9869"
   integrity sha1-pj9oFnOzBXH76LwlaGrnRu76mGk=
 
-minimatch@^3.0.4:
+"minimatch@2 || 3", minimatch@^3.0.4:
   version "3.0.4"
   resolved "https://artifacts.aue1d.saasure.com:443/artifactory/api/npm/npm-okta-master/minimatch/-/minimatch-3.0.4.tgz#5166e286457f03306064be5497e8dbb0c3d32083"
   integrity sha1-UWbihkV/AzBgZL5Ul+jbsMPTIIM=
@@ -5436,6 +5546,14 @@ node-properties-parser@^0.0.2:
   version "0.0.2"
   resolved "https://artifacts.aue1d.saasure.com:443/artifactory/api/npm/npm-okta-master/node-properties-parser/-/node-properties-parser-0.0.2.tgz#cb85a3505596ebe4c03453691ae7d5d77ba84da0"
   integrity sha1-y4WjUFWW6+TANFNpGufV13uoTaA=
+
+node.extend@^1.0.0:
+  version "1.1.8"
+  resolved "https://artifacts.aue1d.saasure.com:443/artifactory/api/npm/npm-okta-master/node.extend/-/node.extend-1.1.8.tgz#0aab3e63789f4e6d68b42bc00073ad1881243cf0"
+  integrity sha1-Cqs+Y3ifTm1otCvAAHOtGIEkPPA=
+  dependencies:
+    has "^1.0.3"
+    is "^3.2.1"
 
 nopt@^4.0.1:
   version "4.0.3"
@@ -6242,7 +6360,7 @@ read@1, read@~1.0.1:
     string_decoder "~1.1.1"
     util-deprecate "~1.0.1"
 
-"readable-stream@2 || 3", readable-stream@3, readable-stream@^3.0.2:
+"readable-stream@2 || 3", readable-stream@3, readable-stream@^3.0.2, readable-stream@^3.1.1:
   version "3.6.0"
   resolved "https://artifacts.aue1d.saasure.com:443/artifactory/api/npm/npm-okta-master/readable-stream/-/readable-stream-3.6.0.tgz#337bbda3adc0706bd3e024426a286d4b4b2c9198"
   integrity sha1-M3u9o63AcGvT4CRCaihtS0sskZg=
@@ -7010,6 +7128,11 @@ strong-log-transformer@^2.0.0:
     duplexer "^0.1.1"
     minimist "^1.2.0"
     through "^2.3.4"
+
+supports-color@^2.0.0:
+  version "2.0.0"
+  resolved "https://artifacts.aue1d.saasure.com:443/artifactory/api/npm/npm-okta-master/supports-color/-/supports-color-2.0.0.tgz#535d045ce6b6363fa40117084629995e9df324c7"
+  integrity sha1-U10EXOa2Nj+kARcIRimZXp3zJMc=
 
 supports-color@^5.3.0:
   version "5.5.0"


### PR DESCRIPTION
### Description

- Migrates existing rules `no-unlocalized-text` and `no-unlocalized-text-in-templates` to a new `courage-app` shared configuration.